### PR TITLE
[Fix] Change the robotnik_msgs branch to switch

### DIFF
--- a/repos/rbvogui_sim_devel_docker.repos
+++ b/repos/rbvogui_sim_devel_docker.repos
@@ -14,7 +14,7 @@ repositories:
   src/robotnik_msgs:
     type: git
     url: https://github.com/RobotnikAutomation/robotnik_msgs
-    version: melodic-devel
+    version: ros-devel
   src/universal_robot:
     type: git
     url: https://github.com/fmauch/universal_robot.git


### PR DESCRIPTION
The original configuration to switch the branch in robotnik_msgs does not exists and make the docker build to crash.